### PR TITLE
[Refactor] Clean up Dockerfile.staging by removing unused base stage

### DIFF
--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,5 +1,2 @@
 # hadolint ignore=DL3006
-FROM ./Dockerfile as base
-
-# hadolint ignore=DL3006
 FROM final-staging as final


### PR DESCRIPTION
- Removed the unused base stage declaration from Dockerfile.staging, streamlining the file and improving clarity in the multi-stage build process.
- This change enhances the organization of the Dockerfile, ensuring that only relevant stages are defined for the build configuration.

## Description

[LIN-XXX] Description du changement

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Refactoring
- [ ] Documentation
- [ ] Infrastructure de développement

## Comment tester le changement

1. Étapes pour tester...
2. ...

## Checklist

- [ ] J'ai testé mes changements localement
- [ ] Mes changements respectent les standards de codage
- [ ] J'ai ajouté des tests pour couvrir mes changements
- [ ] La documentation a été mise à jour
- [ ] Les hooks pre-commit passent avec succès

## Screenshots (si applicable)

## Notes supplémentaires
